### PR TITLE
Update workflow actions off Node 20 runtime

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v3
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       # Generate and transmita copy of our generated SBOM to Manifest
       - name: Transmit generated SBOM to Manifest


### PR DESCRIPTION
PLAT-2209. Bumps workflow actions off the deprecated Node 20 runtime to Node 24 versions, SHA-pinned to the commit each tag resolves to.

| Action | To |
|---|---|
| actions/checkout | `93cb6ef` # v5.0.1 |